### PR TITLE
Prevent accessing removed view on successful DNS connection

### DIFF
--- a/app/src/main/java/com/quad9/aegis/Model/DnsSeeker.java
+++ b/app/src/main/java/com/quad9/aegis/Model/DnsSeeker.java
@@ -32,6 +32,7 @@ import com.google.gson.reflect.TypeToken;
 import com.quad9.aegis.BuildConfig;
 import com.quad9.aegis.MainActivity;
 import com.quad9.aegis.R;
+import com.quad9.aegis.util.LiveEvent;
 
 import org.acra.ACRA;
 import org.acra.config.CoreConfigurationBuilder;
@@ -72,6 +73,7 @@ public class DnsSeeker extends Application {
     static List<ResponseRecord> recentResponse = new ArrayList<ResponseRecord>();
     static List<ResponseRecord> blockedResponse = new ArrayList<ResponseRecord>();
     static List<ResponseRecord> failedResponse = new ArrayList<ResponseRecord>();
+    public static LiveEvent<Void> responsesUpdated = new LiveEvent<>();
     static Lock lock = new ReentrantLock();
     static String lastBlockedTime = "";
     static String lastBlockedDomain = "";
@@ -451,8 +453,7 @@ public class DnsSeeker extends Application {
     }
 
     private static void sendUpdateToActivity() {
-        Intent intent = new Intent("ResponseResult");
-        LocalBroadcastManager.getInstance(getInstance().getApplicationContext()).sendBroadcast(intent);
+        responsesUpdated.set();
     }
 
     // The method is called when a wifi connected but cannot get access to quad9.

--- a/app/src/main/java/com/quad9/aegis/Presenter/Home.java
+++ b/app/src/main/java/com/quad9/aegis/Presenter/Home.java
@@ -60,12 +60,6 @@ public class Home extends Fragment {
     }
 
     @Override
-    public void onDetach() {
-        LocalBroadcastManager.getInstance(requireActivity()).unregisterReceiver(updateReceiver);
-        super.onDetach();
-    }
-
-    @Override
     public void onStart() {
 
         // The problem is that button is listened by onCheckChangedListener. We cannot distinguish it is triggered
@@ -83,8 +77,26 @@ public class Home extends Fragment {
             temp = String.format(getResources().getString(R.string.queries_are_sent), DnsSeeker.getInstance().getTotalCount());
         }
         binding.simpleLog.setText(temp);
-        LocalBroadcastManager.getInstance(requireActivity()).registerReceiver(
-                updateReceiver, new IntentFilter("ResponseResult"));
+        DnsSeeker.responsesUpdated.observe(getViewLifecycleOwner(), _v -> {
+            if (!DnsSeeker.getStatus().recentBlocking()) {
+                String label;
+                if (DnsSeeker.getStatus().isUsingTLS()) {
+                    label = String.format(getResources().getString(R.string.queries_are_secured), DnsSeeker.getInstance().getTotalCount());
+                } else {
+                    label = String.format(getResources().getString(R.string.queries_are_sent), DnsSeeker.getInstance().getTotalCount());
+                }
+                if (binding != null) {
+                    binding.simpleLog.setText(label);
+                    binding.simpleLog.setCompoundDrawablesWithIntrinsicBounds(DnsSeeker.getInstance().getResources().getDrawable(R.drawable.ic_check_white_24dp), null, null, null);
+                }
+            } else {
+                String label = String.format(requireActivity().getResources().getString(R.string.queries_are_blocked), DnsSeeker.getInstance().getBlockedCount());
+                if (binding != null) {
+                    binding.simpleLog.setText(label);
+                    binding.simpleLog.setCompoundDrawablesWithIntrinsicBounds(DnsSeeker.getInstance().getResources().getDrawable(R.drawable.ic_block_white_24dp), null, null, null);
+                }
+            }
+        });
         binding.simpleLog.setOnClickListener(v -> {
             Bundle bundle = new Bundle();
             boolean blocked = false;
@@ -98,28 +110,8 @@ public class Home extends Fragment {
                     .commit();
         });
 
-        if (DnsSeeker.getInstance().getTotalCount() > 200000) {
-            //particleView.setVisibility(View.VISIBLE);
-        }
-
-        BroadcastReceiver networkStatusReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                boolean connected = intent.getBooleanExtra("connected", false);
-                if (connected) {
-                    binding.onOffSwitch.setOnCheckedChangeListener(null);
-                    onStatusConnected();
-                    binding.onOffSwitch.setOnCheckedChangeListener(mOnCheckedChangeListener);
-                } else {
-                    binding.onOffSwitch.setOnCheckedChangeListener(null);
-                    onStatusOff();
-                    binding.onOffSwitch.setOnCheckedChangeListener(mOnCheckedChangeListener);
-                }
-            }
-        };
         LocalBroadcastManager.getInstance(DnsSeeker.getInstance()).registerReceiver(
                 networkStatusReceiver, new IntentFilter(GlobalVariables.NetworkStatus));
-
         if (DnsSeeker.getStatus().isActive()) {
             if (DnsSeeker.getStatus().isConnected()) {
                 // btn_start.setOnCheckedChangeListener(null);
@@ -135,6 +127,12 @@ public class Home extends Fragment {
             binding.onOffSwitch.setOnCheckedChangeListener(mOnCheckedChangeListener);
         }
 
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        LocalBroadcastManager.getInstance(DnsSeeker.getInstance()).unregisterReceiver(networkStatusReceiver);
     }
 
     private CompoundButton.OnCheckedChangeListener mOnCheckedChangeListener;
@@ -194,29 +192,22 @@ public class Home extends Fragment {
     }
 
 
-    private BroadcastReceiver updateReceiver = new BroadcastReceiver() {
+    private BroadcastReceiver networkStatusReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            if (!DnsSeeker.getInstance().getStatus().recentBlocking()) {
-                String temp;
-                if (DnsSeeker.getStatus().isUsingTLS()) {
-                    temp = String.format(getResources().getString(R.string.queries_are_secured), DnsSeeker.getInstance().getTotalCount());
-                } else {
-                    temp = String.format(getResources().getString(R.string.queries_are_sent), DnsSeeker.getInstance().getTotalCount());
-                }
-                if (binding != null) {
-                    binding.simpleLog.setText(temp);
-                    binding.simpleLog.setCompoundDrawablesWithIntrinsicBounds(DnsSeeker.getInstance().getResources().getDrawable(R.drawable.ic_check_white_24dp), null, null, null);
-                }
+            boolean connected = intent.getBooleanExtra("connected", false);
+            if (connected) {
+                binding.onOffSwitch.setOnCheckedChangeListener(null);
+                onStatusConnected();
+                binding.onOffSwitch.setOnCheckedChangeListener(mOnCheckedChangeListener);
             } else {
-                String temp = String.format(requireActivity().getResources().getString(R.string.queries_are_blocked), DnsSeeker.getInstance().getBlockedCount());
-                if (binding != null) {
-                    binding.simpleLog.setText(temp);
-                    binding.simpleLog.setCompoundDrawablesWithIntrinsicBounds(DnsSeeker.getInstance().getResources().getDrawable(R.drawable.ic_block_white_24dp), null, null, null);
-                }
+                binding.onOffSwitch.setOnCheckedChangeListener(null);
+                onStatusOff();
+                binding.onOffSwitch.setOnCheckedChangeListener(mOnCheckedChangeListener);
             }
         }
     };
+
     private TestQuad9.Callback getServerCallback = s -> {
         Analytics.INSTANCE.setCustomCrashlyticsKey("CurrentServer", s);
         String currentNetwork = DnsSeeker.getInstance().getConnectionMonitor().getCurrentNetwork();

--- a/app/src/main/java/com/quad9/aegis/util/LiveEvent.java
+++ b/app/src/main/java/com/quad9/aegis/util/LiveEvent.java
@@ -1,0 +1,31 @@
+package com.quad9.aegis.util;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LiveEvent<T> extends MutableLiveData<T> {
+    private static final String TAG = "LiveEvent";
+
+    private final AtomicBoolean pendingEvent = new AtomicBoolean(false);
+
+    public void observe(@NonNull LifecycleOwner owner, @NonNull Observer<? super T> observer) {
+        super.observe(owner, t -> {
+            if (pendingEvent.compareAndSet(true, false)) {
+                observer.onChanged(t);
+            }
+        });
+    }
+
+    public void setValue(T t) {
+        pendingEvent.set(true);
+        super.setValue(t);
+    }
+
+    public void set() {
+        setValue(null);
+    }
+}


### PR DESCRIPTION
Fixes a crash when app is moved to the background while connection with Quad9 DNS is being established and tested.

This adds a `LiveEvent` class, which is based on `LiveData`, which can be used to cover all kinds of events that were previously tracked with outdated broadcasts.