### PR TITLE
Consistently check if VPN is selected before starting service

### DIFF
--- a/app/src/main/java/com/quad9/aegis/Model/DnsSeeker.java
+++ b/app/src/main/java/com/quad9/aegis/Model/DnsSeeker.java
@@ -85,8 +85,12 @@ public class DnsSeeker extends Application {
 
       switch (msg.what) {
       case MSG_TEST_OK:
-        networkIntent.putExtra("connected", true);
-        activateVpnService();
+        if (VpnService.prepare(DnsSeeker.getInstance()) == null) {
+          networkIntent.putExtra("connected", true);
+          activateVpnService();
+        } else {
+          networkIntent.putExtra("connected", false);
+        }
         LocalBroadcastManager.getInstance(getInstance())
             .sendBroadcast(networkIntent);
         break;


### PR DESCRIPTION
This should prevent crashes related to foreground service startup not allowed.